### PR TITLE
Add SecurityScorecard demo: ServiceNow (direct-pull) and ProcessUnity (chained) patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ VITE_REACT_APP_API_KEY=your-api-key
 VITE_REACT_APP_ORG_ID=your-org-id
 VITE_REACT_APP_ADMIN_USERNAME=username
 VITE_REACT_APP_ADMIN_PASSWORD=password
+VITE_MOCK_LEEN=true
 ```
 
 You can then run the app by running:
@@ -32,4 +33,15 @@ You can then run the app by running:
 ```bash
 bun run dev
 ```
+
+### About `VITE_MOCK_LEEN`
+
+The "SecurityScorecard – ServiceNow" and "SecurityScorecard – ProcessUnity" tiles demonstrate two
+different onRamp integration patterns (see `src/mocks/` and `HostApp.tsx`'s chained-mount flow for
+ProcessUnity's two-connection pairing). With `VITE_MOCK_LEEN=true`, a mock service worker
+intercepts just those two vendors' invite-token/connection-creation calls, so you can click
+through both flows end-to-end without real SecurityScorecard/ProcessUnity credentials — no
+connections are actually created. Every other vendor tile is unaffected and still hits the real
+Leen API. Set `VITE_MOCK_LEEN=false` (or omit it) to have all vendors, including these two, hit
+the real API.
 

--- a/package.json
+++ b/package.json
@@ -37,9 +37,15 @@
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.7",
+    "msw": "^2.15.0",
     "postcss": "^8.4.39",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.2.2",
     "vite": "^5.3.1"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,361 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.15.0'
+const INTEGRITY_CHECKSUM = '03cb67ac84128e63d7cd722a6e5b7f1e'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Omit the body of server-sent event stream responses.
+    // Cloning such responses would prevent client-side stream cancelations
+    // from reaching the original stream (a teed stream only cancels its
+    // source once both of its branches cancel) and would buffer the
+    // entire stream into the unconsumed clone indefinitely.
+    const isEventStreamResponse = response.headers
+      .get('content-type')
+      ?.toLowerCase()
+      .startsWith('text/event-stream')
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = isEventStreamResponse ? null : response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: response.type,
+            status: response.status,
+            statusText: response.statusText,
+            headers: Object.fromEntries(response.headers.entries()),
+            body: responseClone ? responseClone.body : null,
+          },
+        },
+      },
+      responseClone && responseClone.body
+        ? [serializedRequest.body, responseClone.body]
+        : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/src/components/HostApp.tsx
+++ b/src/components/HostApp.tsx
@@ -3,9 +3,10 @@ import { Button } from '@/components/ui/button';
 import useCreateConnection from '@/lib/hooks/useCreateConnectionInviteToken';
 import useGetConnectors, { VendorData } from '@/lib/hooks/useGetConnectors';
 import { LeenOnRamp, LeenOnRampResponse } from '@leendev/onramp';
-import { Loader2, SearchIcon } from 'lucide-react';
+import { CheckCircle2, Loader2, SearchIcon } from 'lucide-react';
 import { toast } from './ui/use-toast';
 import { Toaster } from './ui/toaster';
+import '@/types/onramp-augment.d.ts';
 
 const HostApp = () => {
   const orgId = import.meta.env.VITE_REACT_APP_ORG_ID;
@@ -30,10 +31,19 @@ const HostApp = () => {
   const { createConnection } = useCreateConnection(setIsApiCallInProgress);
   const { getConnectors } = useGetConnectors(setIsApiCallInProgress);
 
+  // Pattern B (ProcessUnity) chained-flow state: two connections, created
+  // back to back, presented to the user as one continuous setup.
+  const [activeLeg, setActiveLeg] = useState<'first' | 'second'>('first');
+  const [firstLegResponse, setFirstLegResponse] = useState<
+    LeenOnRampResponse | undefined
+  >(undefined);
+  const [showTransition, setShowTransition] = useState(false);
+
   const selectedVendor = useMemo(
-    () => dynamicVendorsData.find(v => v.vendor === selectedVendorName),
+    () => dynamicVendorsData.find((v) => v.vendor === selectedVendorName),
     [dynamicVendorsData, selectedVendorName],
   );
+  const isChainedFlow = !!selectedVendor?.chainVendor;
 
   useEffect(() => {
     const fetchVendors = async () => {
@@ -88,8 +98,9 @@ const HostApp = () => {
     setSelectedVendorName(vendor);
   };
 
-  const handleConnect = () => {
+  const startFirstLeg = () => {
     setToken(undefined);
+    setActiveLeg('first');
     const vendorToConnect = selectedVendor?.connectAs ?? selectedVendorName;
     createConnection(apiKey, orgId, vendorToConnect)
       .then((response) => {
@@ -106,16 +117,76 @@ const HostApp = () => {
       });
   };
 
+  const startSecondLeg = (pairedConnectionId: string) => {
+    if (!selectedVendor?.chainVendor) return;
+    setToken(undefined);
+    setActiveLeg('second');
+    // The pairing (options.connection_id) is set server-side, at invite-token
+    // creation time — it's never something the end user sees or enters.
+    createConnection(apiKey, orgId, selectedVendor.chainVendor, {
+      connection_id: pairedConnectionId,
+    })
+      .then((response) => {
+        setToken(response?.data.token);
+        setShowLeenOnRamp(true);
+      })
+      .catch((error) => {
+        toast({
+          title: error.message,
+          variant: 'destructive',
+          description: 'Please try again!',
+        });
+      });
+  };
+
+  const handleConnect = () => {
+    setFirstLegResponse(undefined);
+    setShowTransition(false);
+    startFirstLeg();
+  };
+
+  // Passed to <LeenOnRamp> as setLeenOnRampResponse. For a chained flow's
+  // first leg, this intercepts the "done" signal and routes to the
+  // transition screen instead of the final result screen.
+  const handleLegResponse = (response: LeenOnRampResponse | undefined) => {
+    if (!response) return;
+    if (isChainedFlow && activeLeg === 'first') {
+      setFirstLegResponse(response);
+      setShowLeenOnRamp(false);
+      setShowTransition(true);
+      return;
+    }
+    // Otherwise this is the final leg — close the widget itself so only
+    // this summary shows, rather than stacking on its own success screen.
+    setShowLeenOnRamp(false);
+    setLeenOnRampResponse(response);
+  };
+
+  const handleContinueToSecondLeg = () => {
+    if (!firstLegResponse) return;
+    setShowTransition(false);
+    startSecondLeg(firstLegResponse.data.id);
+  };
+
   const onBack = () => {
     setLeenOnRampResponse(undefined);
     setSelectedVendorName(undefined);
     setToken(undefined);
+    setActiveLeg('first');
+    setFirstLegResponse(undefined);
+    setShowTransition(false);
   };
+
+  const stepLabel = isChainedFlow
+    ? activeLeg === 'first'
+      ? 'Step 1 of 2 — Connect SecurityScorecard'
+      : 'Step 2 of 2 — Connect ProcessUnity'
+    : undefined;
 
   return (
     <div className="flex flex-col justify-center">
       <Toaster />
-      {!leenOnRampResponse && (
+      {!leenOnRampResponse && !showTransition && (
         <div>
           <div className="flex justify-center items-center mt-8 mb-4">
             <div className="relative w-[400px]">
@@ -212,39 +283,88 @@ const HostApp = () => {
           </div>
         </div>
       )}
+
+      {stepLabel && (showLeenOnRamp || showTransition) && (
+        <div className="flex justify-center mb-4">
+          <span className="rounded-full bg-[#2A004E] text-[#B5FF56] text-xs font-semibold px-4 py-1.5 tracking-wide">
+            {stepLabel}
+          </span>
+        </div>
+      )}
+
+      {showTransition && (
+        <div className="flex flex-col items-center gap-3 w-[480px] mx-auto py-16">
+          <CheckCircle2 className="text-green-500" size={40} />
+          <div className="text-lg font-semibold text-center">
+            SecurityScorecard connected
+          </div>
+          <div className="text-sm text-gray-600 text-center max-w-[380px]">
+            Connection{' '}
+            <code className="bg-gray-100 px-1 rounded text-xs">
+              {firstLegResponse?.data.id}
+            </code>{' '}
+            is live. Now let's link it to your ProcessUnity instance so Leen
+            can start syncing.
+          </div>
+          <Button
+            className="bg-[#B5FF56] text-black hover:bg-[#78a43e] mt-4"
+            onClick={handleContinueToSecondLeg}
+          >
+            {isApiCallInProgress ? (
+              <Loader2 className="animate-spin" />
+            ) : (
+              'Continue to ProcessUnity'
+            )}
+          </Button>
+        </div>
+      )}
+
       {showLeenOnRamp && token !== undefined && (
         <LeenOnRamp
           token={token}
           setShowLeenOnRamp={setShowLeenOnRamp}
-          setLeenOnRampResponse={setLeenOnRampResponse}
+          setLeenOnRampResponse={handleLegResponse}
           bundleVersion="dev"
           darkMode={true}
           // bundleVersion="0.0.19"
           darkModeColor={{
-            primary: "#2A004E",
-            secondary: "#500073",
-            border: "#500073",
+            primary: '#2A004E',
+            secondary: '#500073',
+            border: '#500073',
           }}
           {...(selectedVendor?.brandingOverride?.logoUrl && {
             logoUrl: selectedVendor.brandingOverride.logoUrl,
           })}
           {...(selectedVendor?.brandingOverride?.docsUrl && {
             docsUrlOverrides: {
-              [selectedVendor.connectAs ?? selectedVendorName ?? '']: selectedVendor.brandingOverride.docsUrl,
+              [selectedVendor.connectAs ?? selectedVendorName ?? '']:
+                selectedVendor.brandingOverride.docsUrl,
             },
           })}
           {...(selectedVendor?.brandingOverride?.vendorName && {
             vendorName: selectedVendor.brandingOverride.vendorName,
           })}
-          {...(selectedVendor?.generate_api_key && {
-            generate_api_key: selectedVendor.generate_api_key,
-          })}
+          {...(selectedVendor?.generateApiKey && { generateApiKey: true })}
         />
       )}
+
       {leenOnRampResponse && (
-        <div className="flex flex-col">
+        <div className="flex flex-col w-[520px]">
           <div className="text-xl font-semibold mb-4">Response From Leen</div>
-          <pre className="mt-2 rounded-md bg-slate-950 p-4 text-[#B5FF56]">
+          {isChainedFlow && firstLegResponse && (
+            <>
+              <div className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-1">
+                Step 1 — SecurityScorecard
+              </div>
+              <pre className="mb-4 rounded-md bg-slate-950 p-4 text-[#B5FF56] text-xs overflow-x-auto">
+                <code>{JSON.stringify(firstLegResponse, null, 2)}</code>
+              </pre>
+              <div className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-1">
+                Step 2 — ProcessUnity (paired via options.connection_id)
+              </div>
+            </>
+          )}
+          <pre className="mt-2 rounded-md bg-slate-950 p-4 text-[#B5FF56] text-xs overflow-x-auto">
             <code>{JSON.stringify(leenOnRampResponse, null, 2)}</code>
           </pre>
           <Button className="mt-8 ml-auto" onClick={onBack}>

--- a/src/lib/hooks/useCreateConnectionInviteToken.ts
+++ b/src/lib/hooks/useCreateConnectionInviteToken.ts
@@ -9,12 +9,15 @@ function useCreateConnection(
     apiKey: string,
     organizationId: string | undefined,
     vendor: string | undefined,
+    // Server-side-only pairing, e.g. { connection_id: "<ssc connection id>" }
+    // for ProcessUnity. Never accept this from a step the end user controls.
+    options?: Record<string, unknown>,
   ) => {
     setIsApiCallInProgress(true);
     try {
       const response = await axios.post(
         `${baseURl}/provisioning/organizations/${organizationId}/connection-invite-tokens`,
-        { vendor },
+        { vendor, ...(options && { options }) },
         {
           headers: {
             'X-API-KEY': apiKey,

--- a/src/lib/hooks/useGetConnectors.ts
+++ b/src/lib/hooks/useGetConnectors.ts
@@ -9,18 +9,25 @@ interface Connector {
   // Add any other fields you expect from the API response
 }
 
+export interface BrandingOverride {
+  logoUrl?: string;
+  docsUrl?: string;
+  vendorName?: string;
+}
+
 export interface VendorData {
   vendor: string;
   vendorName: string;
   logoUrl: string;
   tag: string;
+  // The real vendor to actually connect as (the tile can be a rebrand of it).
   connectAs?: string;
-  brandingOverride?: {
-    logoUrl?: string;
-    docsUrl?: string;
-    vendorName?: string;
-  };
-  generate_api_key?: boolean;
+  brandingOverride?: BrandingOverride;
+  // Pattern A (ServiceNow): single connection, direct API pull.
+  generateApiKey?: boolean;
+  // Pattern B (ProcessUnity): a second, paired connection created right
+  // after the first one succeeds. See HostApp.tsx for the chained mount.
+  chainVendor?: string;
 }
 
 function useGetConnectors(
@@ -41,21 +48,44 @@ function useGetConnectors(
         logoUrl: connector.logo_url,
         tag: connector.category,
       }));
-      const servicenow = transformedData.find(v => v.vendor === 'SERVICENOW');
-      const sscIndex = transformedData.findIndex(v => v.vendor === 'SECURITY_SCORECARD');
+      const servicenow = transformedData.find((v) => v.vendor === 'SERVICENOW');
+      const sscIndex = transformedData.findIndex(
+        (v) => v.vendor === 'SECURITY_SCORECARD',
+      );
+      const processunity = transformedData.find((v) => v.vendor === 'PROCESSUNITY');
+
       if (sscIndex !== -1 && servicenow) {
+        // Pattern A: direct pull. ServiceNow calls Leen's API itself using a
+        // generated client_id/secret. One connection, one onRamp mount.
         transformedData.splice(sscIndex + 1, 0, {
           vendor: 'securityscorecard_servicenow',
-          vendorName: 'SecurityScoreCard - ServiceNow',
+          vendorName: 'SecurityScorecard – ServiceNow',
           logoUrl: servicenow.logoUrl,
           tag: transformedData[sscIndex].tag,
           connectAs: 'SECURITY_SCORECARD',
           brandingOverride: {
             logoUrl: servicenow.logoUrl,
             docsUrl: 'https://securityscorecard.com/',
-            vendorName: 'SecurityScoreCard - ServiceNow',
+            vendorName: 'SecurityScorecard – ServiceNow',
           },
-          generate_api_key: true,
+          generateApiKey: true,
+        });
+      }
+
+      if (sscIndex !== -1 && processunity) {
+        // Pattern B: paired sync. Leen itself pushes SSC data into
+        // ProcessUnity on a schedule, but that requires TWO connections
+        // wired together — see HostApp.tsx's chained-mount flow. Each leg
+        // keeps its own real vendor branding inside the widget; the "Step
+        // 1 of 2" / "Step 2 of 2" framing lives in HostApp's own chrome,
+        // not the widget header.
+        transformedData.splice(sscIndex + 1, 0, {
+          vendor: 'securityscorecard_processunity',
+          vendorName: 'SecurityScorecard – ProcessUnity',
+          logoUrl: processunity.logoUrl,
+          tag: transformedData[sscIndex].tag,
+          connectAs: 'SECURITY_SCORECARD',
+          chainVendor: 'PROCESSUNITY',
         });
       }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,8 +3,16 @@ import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+async function enableMocksIfConfigured() {
+  if (import.meta.env.VITE_MOCK_LEEN !== 'true') return;
+  const { worker } = await import('./mocks/browser');
+  await worker.start({ onUnhandledRequest: 'bypass' });
+}
+
+enableMocksIfConfigured().then(() => {
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+});

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,0 +1,4 @@
+import { setupWorker } from 'msw/browser';
+import { handlers } from './handlers';
+
+export const worker = setupWorker(...handlers);

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,0 +1,98 @@
+import { http, HttpResponse, JsonBodyType, passthrough } from 'msw';
+import { VENDOR_SCHEMAS } from './schemas';
+import { decodeMockToken, encodeMockToken } from './token';
+
+const MOCK_ORG_ID = '5718a24d-f9c8-4276-af80-088ac433e28f';
+
+// Only these two vendors are mocked — Pattern A (ServiceNow, connects as
+// SECURITY_SCORECARD) and Pattern B (ProcessUnity's paired flow). Every
+// other vendor, and the vendor-tile listing itself, hits the real Leen API
+// exactly as it did before, so nothing else in the demo changes behavior.
+const MOCKED_VENDORS = ['SECURITY_SCORECARD', 'PROCESSUNITY'];
+
+// A real invite-token JWT payload has `vendors` (plural array, from
+// leen_api/adapters/provisioning/provisioning_adapter.py) — only our own
+// mock tokens have a singular `vendor` string. That's the signal used below
+// to tell "one of ours" apart from "a real token, let it through."
+function decodeIfMocked(token: string) {
+  try {
+    const payload = decodeMockToken(token);
+    if (payload?.vendor && MOCKED_VENDORS.includes(payload.vendor)) {
+      return payload;
+    }
+  } catch {
+    // not our token shape — fall through to passthrough
+  }
+  return null;
+}
+
+// Every handler matches on path only (leading "*") so it intercepts the
+// request regardless of which origin actually issues it — the demo app's
+// own hooks and the onRamp bundle's internal calls may target different
+// base URLs depending on how the bundle was built.
+export const handlers = [
+  http.post(
+    '*/provisioning/organizations/:organizationId/connection-invite-tokens',
+    async ({ request }) => {
+      const body = (await request.json()) as {
+        vendor: string;
+        options?: Record<string, unknown>;
+      };
+      if (!MOCKED_VENDORS.includes(body.vendor)) {
+        return passthrough();
+      }
+      const token = encodeMockToken({
+        organization_id: MOCK_ORG_ID,
+        vendor: body.vendor,
+        options: body.options,
+      });
+      return HttpResponse.json({ token });
+    },
+  ),
+
+  http.post(
+    '*/provisioning/organizations/:organizationId/connection-invite-token/validate',
+    async ({ request }) => {
+      const body = (await request.json()) as { token: string };
+      const mocked = decodeIfMocked(body.token);
+      if (!mocked) return passthrough();
+
+      return HttpResponse.json(VENDOR_SCHEMAS[mocked.vendor] as JsonBodyType);
+    },
+  ),
+
+  http.post(
+    '*/provisioning/organizations/:organizationId/connections',
+    async ({ request }) => {
+      const inviteToken = request.headers.get('x-connection-invite-token');
+      const mocked = inviteToken ? decodeIfMocked(inviteToken) : null;
+      if (!mocked) return passthrough();
+
+      const body = (await request.json()) as {
+        generate_api_credentials?: boolean;
+        identifier?: string;
+      };
+
+      return HttpResponse.json({
+        id: crypto.randomUUID(),
+        vendor: mocked.vendor,
+        is_active: true,
+        refresh_interval_secs: 14400,
+        timeout_secs: 3600,
+        organization_id: MOCK_ORG_ID,
+        oauth2_authorize_url: null,
+        identifier: body.identifier ?? null,
+        // Only meaningful for the ServiceNow (direct-pull) pattern.
+        api_credentials: body.generate_api_credentials
+          ? {
+              client_id: crypto.randomUUID(),
+              secret: `mock_secret_${crypto.randomUUID().slice(0, 8)}`,
+            }
+          : null,
+        // Surfaced here only so the demo can show that pairing landed;
+        // the real API never echoes options back on the response.
+        _mock_options: mocked.options ?? null,
+      });
+    },
+  ),
+];

--- a/src/mocks/schemas.ts
+++ b/src/mocks/schemas.ts
@@ -1,0 +1,82 @@
+// JsonForms-shaped credential schemas for the two mocked vendors, matching
+// the real shape served by Leen's onRamp validate-token endpoint (see
+// leen_api/vendor-schema.json for the convention this mirrors).
+
+export const LOGO_BASE = 'https://api.leen.dev/static/img/vendor-logos';
+
+// The vendor tile list itself still comes from the real GET /connectors —
+// only these two vendors' invite-token/validate/create calls are mocked.
+export const VENDOR_SCHEMAS: Record<string, unknown> = {
+  SECURITY_SCORECARD: {
+    vendor: 'SECURITY_SCORECARD',
+    vendorName: 'SecurityScorecard',
+    logoUrl: `${LOGO_BASE}/security_scorecard.png`,
+    docsUrl: 'https://docs.leen.dev/integrations/security-scorecard-credential',
+    credentialsType: 'SECRETS',
+    dataSchema: {
+      type: 'object',
+      properties: {
+        api_key: {
+          type: 'string',
+          password: true,
+          description: 'SecurityScorecard API Key',
+        },
+      },
+      required: ['api_key'],
+    },
+    uiSchema: {
+      type: 'VerticalLayout',
+      elements: [{ type: 'Control', scope: '#/properties/api_key' }],
+    },
+  },
+  PROCESSUNITY: {
+    vendor: 'PROCESSUNITY',
+    vendorName: 'ProcessUnity',
+    logoUrl: `${LOGO_BASE}/processunity.png`,
+    docsUrl: 'https://docs.leen.dev/integrations/processunity-credential',
+    credentialsType: 'SECRETS',
+    dataSchema: {
+      type: 'object',
+      properties: {
+        base_url: {
+          type: 'string',
+          description: 'Your ProcessUnity instance URL',
+        },
+        username: {
+          type: 'string',
+          description: 'API user username',
+        },
+        password: {
+          type: 'string',
+          password: true,
+          description: 'API user password',
+        },
+        third_party_import_template_id: {
+          type: 'integer',
+          description: 'Third Party Import Template ID',
+        },
+        issues_import_template_id: {
+          type: 'integer',
+          description: 'Issues Import Template ID',
+        },
+      },
+      required: [
+        'base_url',
+        'username',
+        'password',
+        'third_party_import_template_id',
+        'issues_import_template_id',
+      ],
+    },
+    uiSchema: {
+      type: 'VerticalLayout',
+      elements: [
+        { type: 'Control', scope: '#/properties/base_url' },
+        { type: 'Control', scope: '#/properties/username' },
+        { type: 'Control', scope: '#/properties/password' },
+        { type: 'Control', scope: '#/properties/third_party_import_template_id' },
+        { type: 'Control', scope: '#/properties/issues_import_template_id' },
+      ],
+    },
+  },
+};

--- a/src/mocks/token.ts
+++ b/src/mocks/token.ts
@@ -1,0 +1,30 @@
+// A deliberately unsigned, JWT-*shaped* token: three dot-separated segments
+// so onRamp's own `parseJwt` (base64url-decodes segment[1], no signature
+// check) can read `organization_id` out of it, exactly like a real invite
+// token. Never do this for anything that isn't a local mock.
+
+function base64UrlEncode(json: unknown): string {
+  const base64 = btoa(JSON.stringify(json));
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64UrlDecode(segment: string): unknown {
+  const base64 = segment.replace(/-/g, '+').replace(/_/g, '/');
+  return JSON.parse(atob(base64));
+}
+
+export interface MockTokenPayload {
+  organization_id: string;
+  vendor: string;
+  options?: Record<string, unknown>;
+}
+
+export function encodeMockToken(payload: MockTokenPayload): string {
+  const header = base64UrlEncode({ alg: 'none', typ: 'mock' });
+  const body = base64UrlEncode(payload);
+  return `${header}.${body}.mock-unsigned`;
+}
+
+export function decodeMockToken(token: string): MockTokenPayload {
+  return base64UrlDecode(token.split('.')[1]) as MockTokenPayload;
+}

--- a/src/types/onramp-augment.d.ts
+++ b/src/types/onramp-augment.d.ts
@@ -1,0 +1,20 @@
+import '@leendev/onramp';
+
+// The published @leendev/onramp@0.0.17 type defs predate onramp PR #50
+// (vendorName / generateApiKey props, api_credentials on the response) and
+// PR #3's SNOW branding work. The deployed "dev" bundle already supports
+// these at runtime; this just lets TypeScript know about them here without
+// waiting on a new npm publish.
+declare module '@leendev/onramp' {
+  interface LeenOnRampProps {
+    vendorName?: string;
+    generateApiKey?: boolean;
+  }
+
+  interface ConnectionResponse {
+    api_credentials?: {
+      client_id: string;
+      secret?: string;
+    } | null;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds two synthetic vendor tiles on top of the real `SECURITY_SCORECARD` connector to demonstrate the two distinct onRamp integration patterns discussed for the SecurityScorecard partnership:
  - **SecurityScorecard – ServiceNow**: single connection, direct API pull. `generateApiKey` surfaces a one-time `client_id`/`secret` in the widget's own success screen.
  - **SecurityScorecard – ProcessUnity**: two connections created back to back in one continuous flow. The second (ProcessUnity) invite token carries `options.connection_id` pointing at the first (SecurityScorecard) connection — matching how Leen's ProcessUnity connector actually pairs with its data source.
- `HostApp.tsx` adds the chained-mount orchestration: a "Step 1 of 2 / Step 2 of 2" indicator, a transition screen between legs, and a combined final summary showing both connections.
- `VITE_MOCK_LEEN=true` (msw) intercepts only these two vendors' invite-token/connection-creation calls, so the flow can be clicked through end-to-end with no real credentials and no real connections created. Every other vendor tile is untouched and still hits the real Leen API.

## Test plan
- [x] `tsc -b` clean
- [x] `eslint` clean (one pre-existing, unrelated warning in `button.tsx`)
- [x] Manually walked the full chained flow (Playwright-driven) against the live "dev" onramp bundle: vendor grid → Step 1 SecurityScorecard form → transition → Step 2 ProcessUnity form (all 5 fields, correct spacing) → final combined summary with `options.connection_id` matching Step 1's connection id
- [x] Confirmed zero console errors and zero real network calls for the two mocked vendors during the flow